### PR TITLE
Add import-map to schema

### DIFF
--- a/schemas/assets.schema.json
+++ b/schemas/assets.schema.json
@@ -117,9 +117,12 @@
             "default": {}
         },
         "import-map": {
-            "type": "string",
-            "minLength": 7,
-            "pattern": "^https?://[a-zA-Z0-9-_./]+(:[0-9]+)?"
+            "type": "array",
+            "items": {
+                "type": "string",
+                "minLength": 7,
+                "pattern": "^https?://[a-zA-Z0-9-_./]+(:[0-9]+)?"
+            }
         }
     },
     "required": ["name", "version", "organisation", "server"]

--- a/schemas/assets.schema.json
+++ b/schemas/assets.schema.json
@@ -23,8 +23,7 @@
         "server": {
             "type": "string",
             "minLength": 7,
-            "pattern": "^https?://[a-zA-Z0-9-_./]+(:[0-9]+)?",
-            "default": ""
+            "pattern": "^https?://[a-zA-Z0-9-_./]+(:[0-9]+)?"
         },
         "js": {
             "type": "object",
@@ -120,8 +119,7 @@
         "import-map": {
             "type": "string",
             "minLength": 7,
-            "pattern": "^https?://[a-zA-Z0-9-_./]+(:[0-9]+)?",
-            "default": ""
+            "pattern": "^https?://[a-zA-Z0-9-_./]+(:[0-9]+)?"
         }
     },
     "required": ["name", "version", "organisation", "server"]

--- a/schemas/assets.schema.json
+++ b/schemas/assets.schema.json
@@ -116,6 +116,12 @@
                 }
             },
             "default": {}
+        },
+        "import-map": {
+            "type": "string",
+            "minLength": 7,
+            "pattern": "^https?://[a-zA-Z0-9-_./]+(:[0-9]+)?",
+            "default": ""
         }
     },
     "required": ["name", "version", "organisation", "server"]

--- a/schemas/index.test.js
+++ b/schemas/index.test.js
@@ -152,7 +152,7 @@ test('js and css fields', t => {
     t.end();
 });
 
-test('import-map field invalid', t => {
+test('import-map field invalid type', t => {
     const result = assets({
         organisation: 'my-org',
         name: 'my-app',
@@ -163,7 +163,25 @@ test('import-map field invalid', t => {
 
     t.equal(
         result.error[0].message,
-        'should match pattern "^https?://[a-zA-Z0-9-_./]+(:[0-9]+)?"'
+        'should be array',
+        'invalid import map type errors'
+    );
+    t.end();
+});
+
+test('import-map field invalid array entry', t => {
+    const result = assets({
+        organisation: 'my-org',
+        name: 'my-app',
+        version: '1.0.0',
+        server: 'http://localhost:4001',
+        'import-map': ['invalid']
+    });
+
+    t.equal(
+        result.error[0].message,
+        'should match pattern "^https?://[a-zA-Z0-9-_./]+(:[0-9]+)?"',
+        'invalid import map array entry errors'
     );
     t.end();
 });
@@ -174,24 +192,60 @@ test('import-map field valid', t => {
         name: 'my-app',
         version: '1.0.0',
         server: 'http://localhost:4001',
-        'import-map': 'http://localhost:4001/finn/map/buzz/v1'
+        'import-map': ['http://localhost:4001/finn/map/buzz/v1']
     });
 
-    t.equal(result.error, false);
-    t.same(result.value, {
+    t.equal(result.error, false, 'no errors in result');
+    t.same(
+        result.value,
+        {
+            organisation: 'my-org',
+            name: 'my-app',
+            version: '1.0.0',
+            server: 'http://localhost:4001',
+            js: {
+                input: '',
+                options: {}
+            },
+            css: {
+                input: '',
+                options: {}
+            },
+            'import-map': ['http://localhost:4001/finn/map/buzz/v1']
+        },
+        'result.value matches output'
+    );
+    t.end();
+});
+
+test('import-map field valid empty array', t => {
+    const result = assets({
         organisation: 'my-org',
         name: 'my-app',
         version: '1.0.0',
         server: 'http://localhost:4001',
-        js: {
-            input: '',
-            options: {}
-        },
-        css: {
-            input: '',
-            options: {}
-        },
-        'import-map': 'http://localhost:4001/finn/map/buzz/v1'
+        'import-map': []
     });
+
+    t.equal(result.error, false, 'result does not return error');
+    t.same(
+        result.value,
+        {
+            organisation: 'my-org',
+            name: 'my-app',
+            version: '1.0.0',
+            server: 'http://localhost:4001',
+            js: {
+                input: '',
+                options: {}
+            },
+            css: {
+                input: '',
+                options: {}
+            },
+            'import-map': []
+        },
+        'result.value matches expected object'
+    );
     t.end();
 });

--- a/schemas/index.test.js
+++ b/schemas/index.test.js
@@ -9,12 +9,12 @@ test('validate basic asset manifest', t => {
         server: 'http://localhost:4001',
         js: {
             input: './assets/scripts.js',
-            options: { async: true, defer: true },
+            options: { async: true, defer: true }
         },
         css: {
             input: './assets/styles.css',
-            options: {},
-        },
+            options: {}
+        }
     });
     t.equal(result.error, false);
     t.end();
@@ -25,7 +25,7 @@ test('validate asset manifest - all props invalid', t => {
         organisation: '',
         name: '',
         version: '',
-        server: '',
+        server: ''
     });
 
     t.equal(result.error[0].dataPath, '.name');
@@ -38,7 +38,7 @@ test('validate asset manifest - all props invalid except name', t => {
         organisation: '',
         name: 'my-app',
         version: '',
-        server: '',
+        server: ''
     });
 
     t.equal(result.error[0].dataPath, '.version');
@@ -51,7 +51,7 @@ test('validate asset manifest - all props invalid except name and version', t =>
         organisation: '',
         name: 'my-app',
         version: '1.0.0',
-        server: '',
+        server: ''
     });
 
     t.equal(result.error[0].dataPath, '.organisation');
@@ -64,7 +64,7 @@ test('validate asset manifest - ', t => {
         organisation: 'my-org',
         name: 'my-app',
         version: '1.0.0',
-        server: '',
+        server: ''
     });
 
     t.equal(result.error[0].dataPath, '.server');
@@ -77,7 +77,7 @@ test('validate asset manifest - ', t => {
         organisation: 'my-org',
         name: 'my-app',
         version: '1.0.0',
-        server: 'asdasdasdasd',
+        server: 'asdasdasdasd'
     });
 
     t.equal(result.error[0].dataPath, '.server');
@@ -93,7 +93,7 @@ test('minimum viable', t => {
         organisation: 'my-org',
         name: 'my-app',
         version: '1.0.0',
-        server: 'http://localhost:4001',
+        server: 'http://localhost:4001'
     });
 
     t.equal(result.error, false);
@@ -103,7 +103,7 @@ test('minimum viable', t => {
         version: '1.0.0',
         server: 'http://localhost:4001',
         js: { input: '', options: {} },
-        css: { input: '', options: {} },
+        css: { input: '', options: {} }
     });
     t.end();
 });
@@ -118,15 +118,15 @@ test('js and css fields', t => {
             input: './assets/scripts.js',
             options: {
                 async: true,
-                defer: true,
-            },
+                defer: true
+            }
         },
         css: {
             input: './assets/styles.css',
             options: {
-                crossorigin: 'etc etc',
-            },
-        },
+                crossorigin: 'etc etc'
+            }
+        }
     });
 
     t.equal(result.error, false);
@@ -139,15 +139,59 @@ test('js and css fields', t => {
             input: './assets/scripts.js',
             options: {
                 async: true,
-                defer: true,
-            },
+                defer: true
+            }
         },
         css: {
             input: './assets/styles.css',
             options: {
-                crossorigin: 'etc etc',
-            },
+                crossorigin: 'etc etc'
+            }
+        }
+    });
+    t.end();
+});
+
+test('import-map field invalid', t => {
+    const result = assets({
+        organisation: 'my-org',
+        name: 'my-app',
+        version: '1.0.0',
+        server: 'http://localhost:4001',
+        'import-map': 'invalid'
+    });
+
+    t.equal(
+        result.error[0].message,
+        'should match pattern "^https?://[a-zA-Z0-9-_./]+(:[0-9]+)?"'
+    );
+    t.end();
+});
+
+test('import-map field valid', t => {
+    const result = assets({
+        organisation: 'my-org',
+        name: 'my-app',
+        version: '1.0.0',
+        server: 'http://localhost:4001',
+        'import-map': 'http://localhost:4001/finn/map/buzz/v1'
+    });
+
+    t.equal(result.error, false);
+    t.same(result.value, {
+        organisation: 'my-org',
+        name: 'my-app',
+        version: '1.0.0',
+        server: 'http://localhost:4001',
+        js: {
+            input: '',
+            options: {}
         },
+        css: {
+            input: '',
+            options: {}
+        },
+        'import-map': 'http://localhost:4001/finn/map/buzz/v1'
     });
     t.end();
 });


### PR DESCRIPTION
Updates `assets.json` JSON schema to include an `import-map` field which can be used to specify the absolute URL to an import-map file